### PR TITLE
make python module build optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ pyo3 = "0.15.1"
 bzip2="0.4"
 
 [features]
-extension-module = ["pyo3/extension-module"]
-default = ["extension-module"]
+py = ["pyo3/extension-module"]
+default = []

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ print(len(paths))
 #### Manually build Python package 
 
 Build for current Python environment:
-`maturin build --release`
+`maturin build --release --features py`
 
 Build using manylinux environment:
-`docker run --rm -v $(pwd):/io konstin2/maturin build`
+`docker run --rm -v $(pwd):/io konstin2/maturin build --release --features py`


### PR DESCRIPTION
This should avoid build issues for Rust-only builds