### PR TITLE
Transverse graph by priority queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ topo = valley_free.load_topology("20161101.as-rel.txt.bz2")
 paths = valley_free.propagate_paths(topo, 15169)
 
 print(len(paths))
-# 110243
+# 117074
 ```
 
 #### Manually build Python package 


### PR DESCRIPTION
I change the graph transverse to a queue prioritizing the UP direction.
This does not affect only the data from dez/2023, the length of all paths for Nov/2016. 

I added a regression test related to issue #4, an extra test to help debug the new implementation besides adding docs to the test with [ascii diagrams](https://asciiflow.com/#/) and reducing the test setup boilerplate with common functions.

resolves #4 