### PR TITLE
Implement topology utils methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ readme = "README.md"
 
 [dependencies]
 petgraph = "0.6.4"
+
+[dev-dependencies]
+rayon = "1.8.1"
+bzip2 = "0.4.4"
+reqwest = { version = "0.11", features = ["blocking"] }

--- a/examples/all_paths.rs
+++ b/examples/all_paths.rs
@@ -1,7 +1,4 @@
-use petgraph::graph::NodeIndex;
 use valley_free::{RelType, Topology};
-
-type GraphPath = Vec<NodeIndex>;
 
 fn main() {
     let topo = Topology::from_edges(vec![
@@ -15,38 +12,7 @@ fn main() {
     let start = 4;
     let topo = topo.paths_graph(start);
 
-    let start_idx = topo.index_of(start).unwrap(); // Node index
-    let mut stack: Vec<(NodeIndex, GraphPath)> = vec![(start_idx, vec![start_idx])];
-    let mut visited: Vec<NodeIndex> = vec![];
-    let mut all_paths: Vec<GraphPath> = vec![];
-
-    while !stack.is_empty() {
-        let (node_idx, path) = stack.pop().unwrap();
-
-        if visited.contains(&node_idx) {
-            continue;
-        }
-
-        visited.push(node_idx);
-        all_paths.push(path.clone());
-
-        let childrens = topo
-            .graph
-            .neighbors_directed(node_idx, petgraph::Direction::Outgoing)
-            .map(|child_idx| {
-                let mut path = path.clone();
-                path.push(child_idx);
-                (child_idx, path)
-            });
-        stack.extend(childrens);
-    }
-
-    for path in all_paths {
-        let path = path
-            .iter()
-            .map(|node_idx| topo.asn_of(*node_idx))
-            .collect::<Vec<_>>();
-
+    for path in topo.path_to_all_ases(start).unwrap() {
         println!("{:?}", path);
     }
 }

--- a/examples/all_paths_between_two_ases.rs
+++ b/examples/all_paths_between_two_ases.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 
-use petgraph::algo::all_simple_paths;
 use valley_free::Topology;
 
 fn main() {
@@ -11,20 +10,11 @@ fn main() {
     let universidade_de_sao_paulo_asn = 28571;
     let ut_path = topo.paths_graph(university_of_twente_asn);
 
-    let paths = all_simple_paths::<Vec<_>, _>(
-        &ut_path.graph,
-        ut_path.index_of(university_of_twente_asn).unwrap(),
-        ut_path.index_of(universidade_de_sao_paulo_asn).unwrap(),
-        0,
-        None,
-    );
-
     println!("Paths from UT to USP:");
-    for path in paths {
-        let path = path
-            .iter()
-            .map(|node| ut_path.asn_of(*node))
-            .collect::<Vec<_>>();
+    for path in ut_path
+        .all_paths_to(university_of_twente_asn, universidade_de_sao_paulo_asn)
+        .unwrap()
+    {
         println!("  {:?}", path);
     }
 }

--- a/examples/shortest_path_between_two_ases.rs
+++ b/examples/shortest_path_between_two_ases.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 
-use petgraph::algo::astar;
-use valley_free::{RelType, Topology};
+use valley_free::Topology;
 
 fn main() {
     let file = File::open("20231201.as-rel.txt").unwrap();
@@ -12,23 +11,9 @@ fn main() {
     let ut_path = topo.paths_graph(university_of_twente_asn);
 
     // Use A* to find the shortest path between two nodes
-    let (_len, path) = astar(
-        &ut_path.graph,
-        ut_path.index_of(university_of_twente_asn).unwrap(),
-        |finish| finish == ut_path.index_of(universidade_de_sao_paulo_asn).unwrap(),
-        |edge| match edge.weight() {
-            // priorize pearing
-            RelType::PearToPear => 0,
-            RelType::ProviderToCustomer => 1,
-            RelType::CustomerToProvider => 2,
-        },
-        |_| 0,
-    )
-    .unwrap();
-    let path = path
-        .iter()
-        .map(|node| ut_path.asn_of(*node))
-        .collect::<Vec<_>>();
+    let path = ut_path
+        .shortest_path_to(university_of_twente_asn, universidade_de_sao_paulo_asn)
+        .unwrap();
 
     println!("Path from UT to USP: {:?}", path);
 }


### PR DESCRIPTION
As discussed [here](https://github.com/bgpkit/valley-free/pull/7#issuecomment-1894902313). This PR creates methods to analyze the graph.
This is the naive implementation based on the examples folder.
I didn't like this implementation because for this method you always need the run the `paths_graph` before, maybe we can create another type `ValleyFreeTopology` that has the guarantee that is a DAG, only been generated by the `paths_graph` and already having the source is inside of them, what do you think?
I also found a bug in the `paths_graph` implementation in the test for the other methods that I will solve here.